### PR TITLE
Extra-headers flag fix

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -47,7 +47,7 @@ const cli = meow(
     --seo=<threshold>             Specify a minimal seo score for the CI to pass.
 
   In addition to listed "lighthouse-ci" configuration flags, it is also possible to pass any native "lighthouse" flag.
-  To see the full list of available flags, please refer to the official Gloogle Lighthouse documentation at https://github.com/GoogleChrome/lighthouse#cli-options
+  To see the full list of available flags, please refer to the official Google Lighthouse documentation at https://github.com/GoogleChrome/lighthouse#cli-options
 `,
   {
     flags: {

--- a/lib/lighthouse-reporter.js
+++ b/lib/lighthouse-reporter.js
@@ -8,6 +8,7 @@
 const lighthouse = require('lighthouse');
 const chromeLauncher = require('chrome-launcher');
 const ReportGenerator = require('lighthouse/lighthouse-core/report/report-generator');
+const fs = require('fs');
 
 const launchChromeAndRunLighthouse = async (
   url,
@@ -23,6 +24,14 @@ const launchChromeAndRunLighthouse = async (
     output: 'json',
     ...lighthouseFlags,
   };
+
+  if (flags.extraHeaders) {
+    let extraHeadersStr = flags.extraHeaders;
+    if (extraHeadersStr.substr(0, 1) !== '{') {
+      extraHeadersStr = fs.readFileSync(extraHeadersStr, 'utf-8');
+    }
+    flags.extraHeaders = JSON.parse(extraHeadersStr);
+  }
 
   const result = await lighthouse(url, flags, config);
   await chrome.kill();


### PR DESCRIPTION
The extra-headers flag for lighthouse is a bit weird, in that it can accept both a file path and stringified JSON. If you try and pass it through currently it will not correctly assert which it is, so if you are providing a file path it will error complaining it is not an object. This just implements some of the same logic from within the lighthouse package [here](https://github.com/GoogleChrome/lighthouse/blob/08db09988a0f6811be8523c0381f66e53609e985/lighthouse-cli/bin.js#L93) that checks it if is JSON otherwise attempts to read from a file.

Also a teeny typo in the usage text, that was almost too cute to fix.