### PR TITLE
Add optional generation of JSON as an output

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ $ lighthouse-ci --help
     -s, --silent                  Run Lighthouse without printing report log
     --report=<path>               Generate an HTML report inside a specified folder
     --filename=<filename>         Specify the name of the generated HTML report file (requires --report)
+    -json, --jsonReport           Generate JSON report in addition to HTML (requires --report)
     --config-path                 The path to the Lighthouse config JSON (read more here: https://github.com/GoogleChrome/lighthouse/blob/master/docs/configuration.md)
     --budget-path                 The path to the Lighthouse budgets config JSON (read more here: https://developers.google.com/web/tools/lighthouse/audits/budgets)
     --score=<threshold>           Specify a score threshold for the CI to pass

--- a/bin/cli
+++ b/bin/cli
@@ -43,6 +43,7 @@ const cli = meow(
     -s, --silent                  Run Lighthouse without printing report log
     --report=<path>               Generate an HTML report inside a specified folder
     --filename=<filename>         Specify the name of the generated HTML report file (requires --report)
+    -json, --jsonReport           Generate JSON report in addition to HTML (requires --report)
     --config-path                 The path to the Lighthouse config JSON (read more here: https://github.com/GoogleChrome/lighthouse/blob/master/docs/configuration.md)
     --budget-path                 The path to the Lighthouse budgets config JSON (read more here: https://developers.google.com/web/tools/lighthouse/audits/budgets)
     --score=<threshold>           Specify a score threshold for the CI to pass
@@ -66,6 +67,11 @@ const cli = meow(
         type: 'string',
         alias: 'f',
         default: 'report.html',
+      },
+      jsonReport: {
+        type: 'boolean',
+        alias: 'json',
+        default: false,
       },
       silent: {
         type: 'boolean',
@@ -104,6 +110,8 @@ const cli = meow(
 const {
   report,
   filename,
+  json,
+  jsonReport,
   silent,
   s,
   score,
@@ -120,6 +128,7 @@ const calculatedBestPractices = bestPractice || bestPractices;
 const flags = {
   report,
   filename,
+  jsonReport: json || jsonReport,
   silent,
   s,
   score,
@@ -138,13 +147,17 @@ function init(args, chromeFlags) {
 
   // Run Google Lighthouse
   return lighthouseReporter(testUrl, flags, chromeFlags, lighthouseFlags).then(
-    async ({ categoryReport, budgetsReport, htmlReport }) => {
+    async ({ categoryReport, budgetsReport, htmlReport, jsonReport }) => {
       const { silent } = flags;
 
       if (flags.report) {
         const outputPath = path.resolve(flags.report, flags.filename);
-
         await fs.writeFileSync(outputPath, htmlReport);
+
+        if (flags.jsonReport && jsonReport) {
+          const jsonReportPath = outputPath.replace(/\.[^\.]+$/, '.json');
+          await fs.writeFileSync(jsonReportPath, jsonReport);
+        }
       }
 
       return {

--- a/lib/lighthouse-reporter.js
+++ b/lib/lighthouse-reporter.js
@@ -84,6 +84,14 @@ const createHtmlReport = (results, flags) => {
   return null;
 };
 
+const createJsonReport = (results, flags) => {
+  if (flags.report && flags.jsonReport) {
+    return ReportGenerator.generateReport(results, 'json');
+  }
+
+  return null;
+};
+
 const createCategoryReport = results => {
   const categoryReport = {};
 
@@ -103,10 +111,11 @@ const createCategoryReport = results => {
 
 const createBudgetsReport = results => {
   const items =
-    results.audits &&
-    results.audits['performance-budget'] &&
-    results.audits['performance-budget'].details &&
-    results.audits['performance-budget'].details.items;
+    (results.audits &&
+      results.audits['performance-budget'] &&
+      results.audits['performance-budget'].details &&
+      results.audits['performance-budget'].details.items) ||
+    [];
 
   const report = items.reduce((acc, obj) => {
     if (obj.countOverBudget) {
@@ -149,10 +158,12 @@ async function writeReport(
   );
 
   const htmlReport = createHtmlReport(lighthouseResult.lhr, flags);
+  const jsonReport = createJsonReport(lighthouseResult.lhr, flags);
+
   const categoryReport = createCategoryReport(lighthouseResult.lhr);
   const budgetsReport = createBudgetsReport(lighthouseResult.lhr);
 
-  return { categoryReport, htmlReport, budgetsReport };
+  return { categoryReport, budgetsReport, htmlReport, jsonReport };
 }
 
 module.exports = writeReport;


### PR DESCRIPTION
Add CLI option to generate JSON report in addition to HTML one. JSON report might be useful to store and upload it somewhere for further processing (e.g. read values and upload into google docs or similar table for tracking overtime)