### PR TITLE
Added passing individual budget thresholds via CLI parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ $ lighthouse-ci --help
     --best-practice=<threshold>   [DEPRECATED] Use best-practices instead
     --best-practices=<threshold>  Specify a minimal best-practice score for the CI to pass
     --seo=<threshold>             Specify a minimal seo score for the CI to pass
+    --budget.<counts|sizes>.<type>    Specify individual budget threshold (if --budget-path not set)
 ```
 
 ## Lighthouse flags
@@ -143,7 +144,7 @@ The generated report inside `reports` folder will follow the custom configuratio
 ## Performance Budget
 
 Lighthouse CI allows you to pass a performance budget configuration file (see [Lighthouse Budgets](https://developers.google.com/web/tools/lighthouse/audits/budgets)).
-There are two options to pass performance budget configs:
+There are several options to pass performance budget configs:
 
 #### Option 1. 
 Add configurations to your `config.json` file like and use instructions above.
@@ -187,6 +188,13 @@ Then run Lighthouse CI with the `--budget-path` flag
 
 ```sh
 $ lighthouse-ci https://example.com --report=reports --budget-path=budget.json
+```
+
+#### Option 3.
+Pass individual parameters via CLI
+
+```sh
+$ lighthouse-ci https://example.com --report=reports --budget.counts.total=20  --budget.sizes.fonts=100000
 ```
 
 ## Contributors

--- a/__tests__/helpers.test.js
+++ b/__tests__/helpers.test.js
@@ -1,6 +1,14 @@
 const mkdirp = require('mkdirp');
 const rimraf = require('rimraf');
-const { clean, createDir, scoreReducer } = require('../lib/helpers');
+const {
+  clean,
+  createDir,
+  scoreReducer,
+  createDefaultConfig,
+  getOwnProps,
+  convertToBudgetList,
+  convertToResourceKey,
+} = require('../lib/helpers');
 
 jest.mock('rimraf');
 jest.mock('mkdirp');
@@ -120,6 +128,108 @@ describe('helpers', () => {
 
       // Assert
       expect(res).toEqual(expectedRes);
+    });
+  });
+
+  describe('getOwnProps', () => {
+    it('should return all own props', () => {
+      // Arrange
+      const expectedProp = 'foo';
+      const mockObj = { foo: 0 };
+
+      // Act
+      const res = getOwnProps(mockObj);
+
+      // Assert
+      expect(res).not.toBeNull();
+      expect(res).toContain(expectedProp);
+      expect(res).toHaveLength(1);
+    });
+
+    it('should not return inherited props', () => {
+      // Arrange
+      const expectedProp = 'foo';
+
+      const Func = function () {
+        this.foo = 1;
+      };
+
+      const input = new Func();
+
+      Func.prototype.bar = 2;
+
+      // Act
+      const res = getOwnProps(input);
+
+      // Assert
+      expect(res).not.toBeNull();
+      expect(res).toContain(expectedProp);
+      expect(res).toHaveLength(1);
+    });
+  });
+
+  describe('createDefaultConfig', () => {
+    it('should not override existing config', () => {
+      // Arrange
+      const expectedConfig = { foo: 1, bar: 2 };
+
+      // Act
+      const res = createDefaultConfig(expectedConfig);
+
+      // Assert
+      expect(res).toEqual(expectedConfig);
+    });
+
+    it('should set `extends` and `settings`', () => {
+      // Arrange
+      const expectedExtends = 'lighthouse:default';
+
+      // Act
+      const res = createDefaultConfig();
+
+      // Assert
+      expect(res.extends).toEqual(expectedExtends);
+      expect(res.settings).not.toBeNull();
+    });
+  });
+
+  describe('convertToBudgetList', () => {
+    it('Should return list of objects in specified format', () => {
+      // Arrange
+      const expected = [
+        {
+          resourceType: 'script',
+          budget: 1,
+        },
+        {
+          resourceType: 'total',
+          budget: 2,
+        },
+      ];
+
+      const input = { script: 1, total: 2 };
+
+      // Act
+      const res = convertToBudgetList(input);
+
+      // Assert
+      expect(res).toHaveLength(2);
+      expect(res).toEqual(expected);
+    });
+  });
+
+  describe('convertToResourceKey', () => {
+    it('Should convert `sizes` to `resourceSizes`', () => {
+      // Arrange
+      const expected = 'resourceSizes';
+
+      const input = 'sizes';
+
+      // Act
+      const res = convertToResourceKey(input);
+
+      // Assert
+      expect(res).toEqual(expected);
     });
   });
 });

--- a/bin/cli
+++ b/bin/cli
@@ -54,6 +54,7 @@ const cli = meow(
     --best-practices=<threshold>  Specify a minimal best-practice score for the CI to pass
     --seo=<threshold>             Specify a minimal seo score for the CI to pass
     --fail-on-budgets             Specify CI should fail if budgets are exceeded
+    --budget.<counts|sizes>.<type>    Specify individual budget threshold (if --budget-path not set)
 
   In addition to listed "lighthouse-ci" configuration flags, it is also possible to pass any native "lighthouse" flag
   To see the full list of available flags, please refer to the official Google Lighthouse documentation at https://github.com/GoogleChrome/lighthouse#cli-options
@@ -103,6 +104,10 @@ const cli = meow(
         type: 'boolean',
         default: false,
       },
+      budget: {
+        type: 'object',
+        default: false,
+      },
     },
   },
 );
@@ -124,6 +129,7 @@ const {
   failOnBudgets,
   ...lighthouseFlags
 } = cli.flags;
+
 const calculatedBestPractices = bestPractice || bestPractices;
 const flags = {
   report,

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -41,4 +41,48 @@ const scoreReducer = (flags, scoreList) => {
   }, {});
 };
 
-module.exports = { clean, createDir, scoreReducer };
+const createDefaultConfig = config => {
+  if (!config) {
+    config = {
+      extends: 'lighthouse:default',
+      settings: {},
+    };
+  }
+
+  if (!config.settings) {
+    config.settings = {};
+  }
+
+  return config;
+};
+
+const getOwnProps = obj => {
+  return Object.keys(obj).filter(key =>
+    Object.prototype.hasOwnProperty.call(obj, key),
+  );
+};
+
+const convertToBudgetList = obj => {
+  return getOwnProps(obj)
+    .filter(key => obj[key])
+    .reduce((acc, key) => {
+      acc.push({
+        resourceType: key,
+        budget: obj[key],
+      });
+      return acc;
+    }, []);
+};
+
+const convertToResourceKey = key =>
+  'resource' + key.charAt(0).toUpperCase() + key.slice(1);
+
+module.exports = {
+  clean,
+  createDir,
+  scoreReducer,
+  createDefaultConfig,
+  getOwnProps,
+  convertToBudgetList,
+  convertToResourceKey,
+};

--- a/lib/lighthouse-reporter.js
+++ b/lib/lighthouse-reporter.js
@@ -11,6 +11,12 @@ const util = require('util');
 const lighthouse = require('lighthouse');
 const chromeLauncher = require('chrome-launcher');
 const ReportGenerator = require('lighthouse/lighthouse-core/report/report-generator');
+const {
+  createDefaultConfig,
+  getOwnProps,
+  convertToBudgetList,
+  convertToResourceKey,
+} = require('./helpers');
 
 const readFile = util.promisify(fs.readFile);
 
@@ -53,21 +59,31 @@ const launchChromeAndRunLighthouse = async (
     try {
       const budgetJson = await readFile(path.resolve(budgetPath), 'UTF-8');
 
-      if (!config) {
-        config = {
-          extends: 'lighthouse:default',
-          settings: {},
-        };
-      }
-
-      if (!config.settings) {
-        config.settings = {};
-      }
+      config = createDefaultConfig(config);
 
       config.settings.budgets = JSON.parse(budgetJson);
     } catch (error) {
       throw new Error(error.message);
     }
+  } else if (flags && flags.budget) {
+    config = createDefaultConfig(config);
+
+    const { budget } = flags;
+
+    const budgetConfigs = getOwnProps(budget)
+      .filter(key => budget[key] && (key === 'counts' || key === 'sizes'))
+      .reduce(
+        (acc, key) => {
+          acc[convertToResourceKey(key)] = convertToBudgetList(budget[key]);
+          return acc;
+        },
+        {
+          resourceSizes: [],
+          resourceCounts: [],
+        },
+      );
+
+    config.settings.budgets = [budgetConfigs];
   }
 
   const result = await lighthouse(url, flags, config);
@@ -93,20 +109,13 @@ const createJsonReport = (results, flags) => {
 };
 
 const createCategoryReport = results => {
-  const categoryReport = {};
+  const { categories } = results;
 
-  for (const categoryName in results.categories) {
-    if (
-      !Object.prototype.hasOwnProperty.call(results.categories, categoryName)
-    ) {
-      continue;
-    }
-
+  return getOwnProps(categories).reduce((categoryReport, categoryName) => {
     const category = results.categories[categoryName];
     categoryReport[category.id] = Math.round(category.score * 100);
-  }
-
-  return categoryReport;
+    return categoryReport;
+  }, {});
 };
 
 const createBudgetsReport = results => {
@@ -122,7 +131,7 @@ const createBudgetsReport = results => {
       acc[obj.resourceType + '-count'] = `${obj.countOverBudget}`;
     }
 
-    if (obj.countOverBudget) {
+    if (obj.sizeOverBudget) {
       acc[obj.resourceType + '-size'] = `${Math.round(
         obj.sizeOverBudget / 1024,
         0,


### PR DESCRIPTION
Added passing individual budget thresholds via CLI parameter `--budget.<counts|sizes>.<type>`
- added tests and README.md updates
- minor refactoring of `createCategoryReport` due to linter complaints

fixes #35 