### PR TITLE
WIP - add plugin support for lighthouse CI

### DIFF
--- a/__tests__/helpers.test.js
+++ b/__tests__/helpers.test.js
@@ -8,6 +8,7 @@ const {
   getOwnProps,
   convertToBudgetList,
   convertToResourceKey,
+  checkFlagsForPlugins
 } = require('../lib/helpers');
 
 jest.mock('rimraf');

--- a/__tests__/helpers.test.js
+++ b/__tests__/helpers.test.js
@@ -125,6 +125,21 @@ describe('helpers', () => {
     });
   });
 
+  describe('checkFlagsForPlugins', () => {
+    it('should convert plugins to an array, for passing into lighthouse', () => {
+      const correctedObj = { plugins: ["lighthouse-plugin-greenhouse"] };
+      const mockObj = { plugins: "lighthouse-plugin-greenhouse" };
+
+      // Act
+      const res = checkFlagsForPlugins(mockObj);
+
+      // Assert
+      expect(res).not.toBeNull();
+      expect(res.plugins).toEqual(correctedObj.plugins)
+      expect(res.plugins).toHaveLength(1);
+    })
+  })
+
   describe('getOwnProps', () => {
     it('should return all own props', () => {
       // Arrange

--- a/__tests__/helpers.test.js
+++ b/__tests__/helpers.test.js
@@ -8,7 +8,7 @@ const {
   getOwnProps,
   convertToBudgetList,
   convertToResourceKey,
-  checkFlagsForPlugins
+  checkFlagsForPlugins,
 } = require('../lib/helpers');
 
 jest.mock('rimraf');
@@ -128,18 +128,18 @@ describe('helpers', () => {
 
   describe('checkFlagsForPlugins', () => {
     it('should convert plugins to an array, for passing into lighthouse', () => {
-      const correctedObj = { plugins: ["lighthouse-plugin-greenhouse"] };
-      const mockObj = { plugins: "lighthouse-plugin-greenhouse" };
+      const correctedObj = { plugins: ['lighthouse-plugin-greenhouse'] };
+      const mockObj = { plugins: 'lighthouse-plugin-greenhouse' };
 
       // Act
       const res = checkFlagsForPlugins(mockObj);
 
       // Assert
       expect(res).not.toBeNull();
-      expect(res.plugins).toEqual(correctedObj.plugins)
+      expect(res.plugins).toEqual(correctedObj.plugins);
       expect(res.plugins).toHaveLength(1);
-    })
-  })
+    });
+  });
 
   describe('getOwnProps', () => {
     it('should return all own props', () => {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -69,6 +69,12 @@ const convertToBudgetList = obj => {
       return acc;
     }, []);
 };
+const checkFlagsForPlugins = obj => {
+  if (obj['plugins']) {
+    obj.plugins = [obj.plugins]
+  }
+  return obj
+}
 
 const convertToResourceKey = key => 'resource' + key.charAt(0).toUpperCase() + key.slice(1);
 
@@ -80,4 +86,5 @@ module.exports = {
   getOwnProps,
   convertToBudgetList,
   convertToResourceKey,
+  checkFlagsForPlugins
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -69,12 +69,14 @@ const convertToBudgetList = obj => {
       return acc;
     }, []);
 };
+
 const checkFlagsForPlugins = obj => {
-  if (obj['plugins']) {
-    obj.plugins = [obj.plugins]
+  if (obj.plugins) {
+    obj.plugins = [obj.plugins];
   }
-  return obj
-}
+
+  return obj;
+};
 
 const convertToResourceKey = key => 'resource' + key.charAt(0).toUpperCase() + key.slice(1);
 
@@ -86,5 +88,5 @@ module.exports = {
   getOwnProps,
   convertToBudgetList,
   convertToResourceKey,
-  checkFlagsForPlugins
+  checkFlagsForPlugins,
 };

--- a/lib/lighthouse-reporter.js
+++ b/lib/lighthouse-reporter.js
@@ -11,7 +11,13 @@ const util = require('util');
 const lighthouse = require('lighthouse');
 const chromeLauncher = require('chrome-launcher');
 const ReportGenerator = require('lighthouse/lighthouse-core/report/report-generator');
-const { createDefaultConfig, getOwnProps, convertToBudgetList, convertToResourceKey, checkFlagsForPlugins } = require('./helpers');
+const {
+  createDefaultConfig,
+  getOwnProps,
+  convertToBudgetList,
+  convertToResourceKey,
+  checkFlagsForPlugins,
+} = require('./helpers');
 
 const readFile = util.promisify(fs.readFile);
 
@@ -19,8 +25,8 @@ const launchChromeAndRunLighthouse = async (url, chromeFlags, lighthouseFlags, c
   const chrome = await chromeLauncher.launch({
     chromeFlags,
   });
-  // parse plugin flags
-  const parsedLighthouseFlags = checkFlagsForPlugins(lighthouseFlags)
+  // Parse plugin flags
+  const parsedLighthouseFlags = checkFlagsForPlugins(lighthouseFlags);
 
   const flags = {
     port: chrome.port,

--- a/lib/lighthouse-reporter.js
+++ b/lib/lighthouse-reporter.js
@@ -11,7 +11,7 @@ const util = require('util');
 const lighthouse = require('lighthouse');
 const chromeLauncher = require('chrome-launcher');
 const ReportGenerator = require('lighthouse/lighthouse-core/report/report-generator');
-const { createDefaultConfig, getOwnProps, convertToBudgetList, convertToResourceKey } = require('./helpers');
+const { createDefaultConfig, getOwnProps, convertToBudgetList, convertToResourceKey, checkFlagsForPlugins } = require('./helpers');
 
 const readFile = util.promisify(fs.readFile);
 
@@ -19,10 +19,13 @@ const launchChromeAndRunLighthouse = async (url, chromeFlags, lighthouseFlags, c
   const chrome = await chromeLauncher.launch({
     chromeFlags,
   });
+  // parse plugin flags
+  const parsedLighthouseFlags = checkFlagsForPlugins(lighthouseFlags)
+
   const flags = {
     port: chrome.port,
     output: 'json',
-    ...lighthouseFlags,
+    ...parsedLighthouseFlags,
   };
   let config;
 


### PR DESCRIPTION
_This isn't ready for PR yet._

We need these answered first, and then the PR coded to the necessary standards:

- [ ] I've added a plugin adapter in the helpers file in the PR - I'll tidy up the code in a bit, but is this an okay place to put it?
- [ ] it would be good to support a more sensible name than `lighthouse-plugin` for plugin names. any idea how these are set in the CLI output?
- [ ] if I wanted to support setting budgets for plugins in future, what would I need to extend to support this so a test failed on these too, like we have for the other flags?
