### PR TITLE
Codechecks MVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,23 @@ $ npm install -g lighthouse-ci
 
 ## Table of Contents
 
-- [Lighthouse CI](#lighthouse-ci)
-  - [Install](#install)
-  - [Table of Contents](#table-of-contents)
-  - [Usage](#usage)
-  - [CLI](#cli)
-  - [Lighthouse flags](#lighthouse-flags)
-    - [Chrome flags](#chrome-flags)
-  - [Configuration](#configuration)
-  - [Performance Budgets](#performance-budget)
-  - [Contributors](#contributors)
-  - [License](#license)
+- [Lighthouse CI](#Lighthouse-CI)
+  - [Install](#Install)
+  - [Table of Contents](#Table-of-Contents)
+  - [Usage](#Usage)
+  - [CLI](#CLI)
+  - [Lighthouse flags](#Lighthouse-flags)
+    - [Chrome flags](#Chrome-flags)
+  - [Configuration](#Configuration)
+  - [Performance Budget](#Performance-Budget)
+      - [Option 1.](#Option-1)
+      - [Option 2.](#Option-2)
+      - [Option 3.](#Option-3)
+  - [How to](#How-to)
+    - [Test a page that requires authentication](#Test-a-page-that-requires-authentication)
+    - [Wait for post-load JavaScript to execute before ending a trace](#Wait-for-post-load-JavaScript-to-execute-before-ending-a-trace)
+  - [Contributors](#Contributors)
+  - [License](#License)
 
 ## Usage
 
@@ -146,7 +152,7 @@ The generated report inside `reports` folder will follow the custom configuratio
 Lighthouse CI allows you to pass a performance budget configuration file (see [Lighthouse Budgets](https://developers.google.com/web/tools/lighthouse/audits/budgets)).
 There are several options to pass performance budget configs:
 
-#### Option 1. 
+#### Option 1.
 Add configurations to your `config.json` file like and use instructions above.
 ``` json
 {
@@ -195,6 +201,52 @@ Pass individual parameters via CLI
 
 ```sh
 $ lighthouse-ci https://example.com --report=reports --budget.counts.total=20  --budget.sizes.fonts=100000
+```
+
+## How to
+
+### Test a page that requires authentication
+
+By default `lighthouse-cli` is just creating the report against a specific URL without letting the engineer to interact with the browser.
+Sometimes, however, the page for which you want to generate the report, requires the user to be authenticated.
+Depending on the authentication mechanism, you can inject extra header information into the page.
+
+```sh
+lighthouse-ci https://example.com --extra-headers=./extra-headers.js
+```
+
+Where `extra-headers.json` contains:
+
+```js
+module.exports = {
+  Authorization: 'Bearer MyAccessToken',
+  Cookie: "user=MySecretCookie;"
+};
+```
+
+### Wait for post-load JavaScript to execute before ending a trace
+
+Your website might require extra time to load and execute all the JavaScript logic.
+It is possible to let LightHouse wait for a certain amount of time, before ending a trace,
+by providing a `pauseAfterLoadMs` value to a custom configuration file.
+
+eg.
+
+```sh
+lighthouse-ci https://example.com --config-path ./config.json
+```
+
+Where `config.json` contains:
+
+```json
+{
+  "extends": "lighthouse:default",
+  "passes": [{
+    "recordTrace": true,
+    "pauseAfterLoadMs": 5000,
+    "networkQuietThresholdMs": 5000
+  }]
+}
 ```
 
 ## Contributors

--- a/bin/codecheck.js
+++ b/bin/codecheck.js
@@ -1,0 +1,120 @@
+const { join } = require('path');
+const fs = require('fs');
+const { codechecks } = require('@codechecks/client');
+const { dir } = require('tmp-promise');
+const table = require('markdown-table');
+
+const lighthouseReporter = require('../lib/lighthouse-reporter');
+const { getChromeFlags } = require('../lib/config');
+
+const ARTIFACT_ROOT = 'lighthouse-ci';
+
+module.exports = async options => {
+  const lighthouseReport = await lighthouseReporter(options.url, { report: true }, getChromeFlags(), {});
+
+  const metrics = lighthouseReport.categoryReport;
+  const { htmlReport } = lighthouseReport;
+
+  codechecks.saveValue(`${ARTIFACT_ROOT}/metrics.json`, metrics);
+  const reportLink = await uploadHtmlReport(htmlReport);
+
+  if (!codechecks.isPr()) {
+    return;
+  }
+
+  const baseBranchArtifact = await codechecks.getValue(`${ARTIFACT_ROOT}/metrics.json`);
+
+  const artifactComparison = compareArtifacts(baseBranchArtifact, metrics);
+
+  await codechecks.success({
+    name: 'Lighthouse CI',
+    shortDescription: getShortDescription(artifactComparison, baseBranchArtifact),
+    longDescription: getLongDescription(artifactComparison),
+    detailsUrl: reportLink,
+  });
+};
+
+async function uploadHtmlReport(htmlReport) {
+  const { path: randomDir } = await dir();
+  const outputPath = join(randomDir, 'lighthouse-report.html');
+
+  fs.writeFileSync(outputPath, htmlReport);
+  await codechecks.saveFile(`${ARTIFACT_ROOT}/report.html`, outputPath);
+
+  return codechecks.getArtifactLink(`${ARTIFACT_ROOT}/report.html`);
+}
+
+function compareArtifacts(base = {}, head) {
+  function diffFor(key, name) {
+    if (!head[key]) {
+      return undefined;
+    }
+
+    return {
+      name,
+      value: head[key],
+      diff: head[key] - (base[key] || 0),
+    };
+  }
+
+  return [
+    diffFor('performance', 'Performance'),
+    diffFor('accessibility', 'Accessibility'),
+    diffFor('best-practices', 'Best practices'),
+    diffFor('seo', 'SEO'),
+    diffFor('pwa', 'PWA'),
+  ].filter(d => Boolean(d));
+}
+
+function getShortDescription(artifactComparison, base) {
+  if (!base) {
+    return 'New Lighthouse report generated!';
+  }
+
+  const decreased = artifactComparison.filter(c => c.diff < 0).length;
+  const increased = artifactComparison.filter(c => c.diff > 0).length;
+
+  if (decreased > 0) {
+    return `${decreased} metrics decreased, be careful!`;
+  }
+
+  if (increased > 0) {
+    return `${increased} metrics got better, good job!`;
+  }
+
+  return `No changes in metrics detected!`;
+}
+
+function getLongDescription(artifactComparison) {
+  // prettier-ignore
+  const rows = [
+    ['Name', 'Status', 'Score'],
+    ...artifactComparison.map(a => [a.name, `${getIcon(a.diff)} ${diffWithSign(a.diff)}`, a.value])
+  ]
+
+  return table(rows) + '\n';
+}
+
+function getIcon(diff) {
+  if (diff > 0) {
+    return '✅';
+  }
+
+  if (diff < 0) {
+    return '🔴';
+  }
+
+  return '';
+}
+
+function diffWithSign(value) {
+  if (value > 0) {
+    return `+${value}`;
+  }
+
+  if (value < 0) {
+    return value.toString();
+  }
+
+  return '-';
+}

--- a/codechecks.yml
+++ b/codechecks.yml
@@ -1,7 +1,0 @@
-- name: ./bin/cli
-    options:
-      - name: node-gyp
-        reason: "No native modules please! They make installation much harder"
-settings:
-  branches:
-    - master

--- a/demo/codechecks.yml
+++ b/demo/codechecks.yml
@@ -1,0 +1,4 @@
+checks:
+  - name: ../bin/codecheck.js
+    options:
+      url: https://google.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lighthouse-ci",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7474,6 +7474,11 @@
         "object-visit": "^1.0.0"
       }
     },
+    "markdown-table": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.3.tgz",
+      "integrity": "sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q=="
+    },
     "marked": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.6.3.tgz",
@@ -10625,6 +10630,24 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "requires": {
         "os-tmpdir": "~1.0.2"
+      }
+    },
+    "tmp-promise": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-2.0.2.tgz",
+      "integrity": "sha512-zl71nFWjPKW2KXs+73gEk8RmqvtAeXPxhWDkTUoa3MSMkjq3I+9OeknjF178MQoMYsdqL730hfzvNfEkePxq9Q==",
+      "requires": {
+        "tmp": "0.1.0"
+      },
+      "dependencies": {
+        "tmp": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
+          "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+          "requires": {
+            "rimraf": "^2.6.3"
+          }
+        }
       }
     },
     "tmpl": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lighthouse-ci",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "CLI implementation for running Lighthouse with any CI tool",
   "scripts": {
     "test": "npm run format && xo && jest",
@@ -54,7 +54,10 @@
       "jest"
     ],
     "rules": {
-      "max-params": ["error", 5]
+      "max-params": [
+        "error",
+        5
+      ]
     }
   },
   "author": "Andrea Sonny <andreasonny83@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -13,10 +13,12 @@
   "dependencies": {
     "chrome-launcher": "^0.11.1",
     "lighthouse": "^5.1.0",
+    "markdown-table": "^1.1.3",
     "meow": "^5.0.0",
     "mkdirp": "^0.5.1",
     "ora": "^3.4.0",
     "rimraf": "^2.6.3",
+    "tmp-promise": "^2.0.2",
     "update-notifier": "^3.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Stores HTML report and compares difference between metrics.

What can be improved:
- formatting of a table in long description. Diff column should be IMO right aligned
- currently I needed to run `http-server` in example repo before running codechecks because lighthouse needs URL. I think whats way more convenient is that `lighthouse-ci` would have option to provider directory and then spawn http server in the background and provide URL to lighthouse.


See it in action: (headers are linked)

## [First run:](https://github.com/krzkaczor/cc-prod-playground/pull/7)

![image](https://user-images.githubusercontent.com/1814312/62809167-7809a880-bafa-11e9-9932-395f8bb296bc.png)

![image](https://user-images.githubusercontent.com/1814312/62809289-cc148d00-bafa-11e9-9d7e-1806cfec0d06.png)

## [Second run (there is a baseline for master):](https://github.com/krzkaczor/cc-prod-playground/pull/8)

![image](https://user-images.githubusercontent.com/1814312/62809761-28c47780-bafc-11e9-9225-ff6ff274b51a.png)

![image](https://user-images.githubusercontent.com/1814312/62809721-0c283f80-bafc-11e9-9f67-0b1b5337f14d.png)

# Testing

Locally you can run `npx codehecks ./demo/codechecks.yml` which will run codechecks in offline mode. In this case you won't be able to replicate case when there was a baseline and pr. To do this I advice for now just to create a dummy repository and test it there (I did the same).
