### PR TITLE
fix: correct budget type from cli

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -105,7 +105,7 @@ const cli = meow(
         default: false,
       },
       budget: {
-        type: 'object',
+        type: 'boolean',
         default: false,
       },
     },


### PR DESCRIPTION
Hi,
I'm not sure this is the exact correction, but right now, since https://github.com/andreasonny83/lighthouse-ci/releases/tag/v1.10.1, running `yarn lighthouse-ci https://www.wikipedia.org/` results in:
```console
$ yarn lighthouse-ci https://www.wikipedia.org/                          

yarn run v1.19.1
warning package.json: No license field
$ /private/tmp/node_modules/.bin/lighthouse-ci https://www.wikipedia.org/
/private/tmp/node_modules/minimist-options/index.js:84
					throw new TypeError(`Expected type of "${key}" to be one of ${prettyPrint(availableTypes)}, got ${prettyPrint(type)}`);
					^

TypeError: Expected type of "budget" to be one of ["string", "boolean", "number", "array", "string-array", "boolean-array", "number-array"], got "object"
    at /private/tmp/node_modules/minimist-options/index.js:84:12
    at Array.forEach (<anonymous>)
    at buildOptions (/private/tmp/node_modules/minimist-options/index.js:64:23)
    at meow (/private/tmp/node_modules/meow/index.js:65:18)
    at Object.<anonymous> (/private/tmp/node_modules/lighthouse-ci/bin/cli:29:13)
    at Module._compile (internal/modules/cjs/loader.js:936:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:947:10)
    at Module.load (internal/modules/cjs/loader.js:790:32)
    at Function.Module._load (internal/modules/cjs/loader.js:703:12)
    at Function.Module.runMain (internal/modules/cjs/loader.js:999:10)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Changing budget type in `bin/cli`, from object to boolean, makes the command works.