### PR TITLE
fix: correct arguments order for `launchChromeAndRunLighthouse` function

### DIFF
--- a/lib/lighthouse-reporter.js
+++ b/lib/lighthouse-reporter.js
@@ -134,10 +134,13 @@ async function writeReport(url, flags = {}, defaultChromeFlags = [], lighthouseF
   const { chromeFlags, configPath, budgetPath, ...extraLHFlags } = lighthouseFlags;
   const customChromeFlags = chromeFlags ? chromeFlags.split(',') : [];
 
-  const lighthouseResult = await launchChromeAndRunLighthouse(url, extraLHFlags, configPath, budgetPath, [
-    ...defaultChromeFlags,
-    ...customChromeFlags,
-  ]);
+  const lighthouseResult = await launchChromeAndRunLighthouse(
+    url,
+    [...defaultChromeFlags, ...customChromeFlags],
+    extraLHFlags,
+    configPath,
+    budgetPath,
+  );
 
   const htmlReport = createHtmlReport(lighthouseResult.lhr, flags);
   const jsonReport = createJsonReport(lighthouseResult.lhr, flags);


### PR DESCRIPTION
Hi,

Last version ([v1.10.3](https://github.com/andreasonny83/lighthouse-ci/releases/tag/v1.10.3)) fails with the following error:
```console
$ yarn lighthouse-ci https://www.wikipedia.org/

yarn run v1.19.1
[...]
TypeError: Found non-callable @@iterator
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

It seems like arguments order for function `launchChromeAndRunLighthouse` (`lighthouse-reporter.js`) has been changed unexpectedly in commit af5567816fe2ed0ff4ac3de22cb79e954d062eb5.

Non-regression test: https://github.com/andreasonny83/lighthouse-ci/pull/72
Fixes https://github.com/andreasonny83/lighthouse-ci/issues/73

Thanking you in advance