### PR TITLE
test: ensure that the `reporter` is working correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
 language: node_js
 node_js:
   - '10.13'
+before_script:
+  - export DISPLAY=:99.0
+  - export CHROME_PATH="$(pwd)/chrome-linux/chrome"
+services:
+  - xvfb
+addons:
+  chrome: stable

--- a/__tests__/reporter.test.js
+++ b/__tests__/reporter.test.js
@@ -1,0 +1,22 @@
+const writeReport = require('../lib/lighthouse-reporter');
+
+describe('Reporter', () => {
+  it('should launch Chrome and generate a report', async () => {
+    jest.setTimeout(20000); // Allows more time to run all tests
+    const result = await writeReport('http://www.google.com');
+    expect(result).toEqual(
+      expect.objectContaining({
+        categoryReport: {
+          performance: expect.any(Number),
+          accessibility: expect.any(Number),
+          'best-practices': expect.any(Number),
+          seo: expect.any(Number),
+          pwa: expect.any(Number),
+        },
+        budgetsReport: expect.any(Object),
+        htmlReport: expect.any(Object),
+        jsonReport: expect.any(Object),
+      }),
+    );
+  });
+});

--- a/lib/lighthouse-reporter.js
+++ b/lib/lighthouse-reporter.js
@@ -134,10 +134,13 @@ async function writeReport(url, flags = {}, defaultChromeFlags = [], lighthouseF
   const { chromeFlags, configPath, budgetPath, ...extraLHFlags } = lighthouseFlags;
   const customChromeFlags = chromeFlags ? chromeFlags.split(',') : [];
 
-  const lighthouseResult = await launchChromeAndRunLighthouse(url, extraLHFlags, configPath, budgetPath, [
-    ...defaultChromeFlags,
-    ...customChromeFlags,
-  ]);
+  const lighthouseResult = await launchChromeAndRunLighthouse(
+    url,
+    [...defaultChromeFlags, ...customChromeFlags],
+    extraLHFlags,
+    configPath,
+    budgetPath,
+  );
 
   const htmlReport = createHtmlReport(lighthouseResult.lhr, flags);
   const jsonReport = createJsonReport(lighthouseResult.lhr, flags);


### PR DESCRIPTION
Add a new test that will generate a `lighthouse-ci` report on `http://www.google.com`, to ensure that future changes won't break this feature.

See also https://github.com/andreasonny83/lighthouse-ci/pull/71.