### PR TITLE
Ignore vscode .history directory when running tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,9 @@
     "README.md",
     "LICENSE"
   ],
+  "jest": {
+    "testPathIgnorePatterns": [".history"]
+  },
   "engines": {
     "node": ">=10.13"
   },

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "url": "git+https://github.com/andreasonny83/lighthouse-ci.git"
   },
   "bugs": {
-    "url": "https://github.com/andreasonny83/lighthouse-ci.git/issues"
+    "url": "https://github.com/andreasonny83/lighthouse-ci/issues"
   },
   "homepage": "https://github.com/andreasonny83/lighthouse-ci.git#readme",
   "snyk": true


### PR DESCRIPTION
The local history plugin in vscode creates a .history directory in the project workspace (by default, though it can be configured). 

Jest will try to run any tests it find in there (which it will if you are editing tests) and they will cause failures. 

Sounds silly but it took me the best part of an hour to work out what was causing the tests to fail 🤦 

I noticed you have vscode users, there is an entry in the .gitignore, so I offer this minor tweak in the hope it will help others 🥰 
