### PR TITLE
Download Chromium optionally if no Chrome found

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 registry=https://registry.npmjs.org/
 package-lock=false
+node_chromium_skip_install=true

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ $ lighthouse-ci --help
     --seo=<threshold>             Specify a minimal seo score for the CI to pass
     --budget.<counts|sizes>.<type>    Specify individual budget threshold (if --budget-path not set)
     --chromium-fallback           If no Chrome installations are found download and use Chromium browser instead
+    --chromium-force              Always download and use Chromium browser.
 ```
 
 ## Lighthouse flags

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ $ lighthouse-ci --help
     --best-practices=<threshold>  Specify a minimal best-practice score for the CI to pass
     --seo=<threshold>             Specify a minimal seo score for the CI to pass
     --budget.<counts|sizes>.<type>    Specify individual budget threshold (if --budget-path not set)
+    --chromium-fallback           If no Chrome installations are found download and use Chromium browser instead
 ```
 
 ## Lighthouse flags

--- a/__tests__/reporter.test.js
+++ b/__tests__/reporter.test.js
@@ -2,8 +2,8 @@ const writeReport = require('../lib/lighthouse-reporter');
 
 describe('Reporter', () => {
   it('should launch Chrome and generate a report', async () => {
-    jest.setTimeout(20000); // Allows more time to run all tests
-    const result = await writeReport('http://www.google.com');
+    jest.setTimeout(60000); // Allows more time to run all tests
+    const result = await writeReport('http://www.google.com', { chromiumFallback: true });
     expect(result).toEqual(
       expect.objectContaining({
         categoryReport: {

--- a/bin/cli
+++ b/bin/cli
@@ -55,6 +55,8 @@ const cli = meow(
     --seo=<threshold>               Specify a minimal seo score for the CI to pass
     --fail-on-budgets               Specify CI should fail if budgets are exceeded
     --budget.<counts|sizes>.<type>  Specify individual budget threshold (if --budget-path not set)
+    --chromium-fallback             If no Chrome installations are found download and use Chromium browser instead
+    --chromium-force                Always download and use Chromium browser.
 
   In addition to listed "lighthouse-ci" configuration flags, it is also possible to pass any native "lighthouse" flag
   To see the full list of available flags, please refer to the official Google Lighthouse documentation at https://github.com/GoogleChrome/lighthouse#cli-options
@@ -111,6 +113,10 @@ const cli = meow(
         type: 'boolean',
         default: false,
       },
+      chromiumForce: {
+        type: 'boolean',
+        default: false,
+      },
     },
   },
 );
@@ -131,6 +137,7 @@ const {
   seo,
   failOnBudgets,
   chromiumFallback,
+  chromiumForce,
   ...lighthouseFlags
 } = cli.flags;
 
@@ -151,6 +158,7 @@ const flags = {
   seo,
   failOnBudgets,
   chromiumFallback,
+  chromiumForce,
 };
 
 function init(args, chromeFlags) {

--- a/bin/cli
+++ b/bin/cli
@@ -107,6 +107,10 @@ const cli = meow(
       budget: {
         type: 'string',
       },
+      chromiumFallback: {
+        type: 'boolean',
+        default: false,
+      },
     },
   },
 );
@@ -126,6 +130,7 @@ const {
   bestPractices,
   seo,
   failOnBudgets,
+  chromiumFallback,
   ...lighthouseFlags
 } = cli.flags;
 
@@ -145,6 +150,7 @@ const flags = {
   }),
   seo,
   failOnBudgets,
+  chromiumFallback,
 };
 
 function init(args, chromeFlags) {

--- a/lib/lighthouse-reporter.js
+++ b/lib/lighthouse-reporter.js
@@ -10,6 +10,7 @@ const path = require('path');
 const util = require('util');
 const lighthouse = require('lighthouse');
 const chromeLauncher = require('chrome-launcher');
+const chromium = require('chromium');
 const ReportGenerator = require('lighthouse/lighthouse-core/report/report-generator');
 const { createDefaultConfig, getOwnProps, convertToBudgetList, convertToResourceKey } = require('./helpers');
 
@@ -130,9 +131,24 @@ const createBudgetsReport = results => {
   return report;
 };
 
+const checkChromiumFallback = async () => {
+  const installations = chromeLauncher.Launcher.getInstallations();
+  if (installations.length === 0) {
+    if (!chromium.path) {
+      await chromium.install();
+    }
+
+    process.env.CHROME_PATH = chromium.path;
+  }
+};
+
 async function writeReport(url, flags = {}, defaultChromeFlags = [], lighthouseFlags = {}) {
   const { chromeFlags, configPath, budgetPath, ...extraLHFlags } = lighthouseFlags;
   const customChromeFlags = chromeFlags ? chromeFlags.split(',') : [];
+
+  if (flags.chromiumFallback) {
+    await checkChromiumFallback();
+  }
 
   const lighthouseResult = await launchChromeAndRunLighthouse(
     url,

--- a/lib/lighthouse-reporter.js
+++ b/lib/lighthouse-reporter.js
@@ -134,19 +134,25 @@ const createBudgetsReport = results => {
 const checkChromiumFallback = async () => {
   const installations = chromeLauncher.Launcher.getInstallations();
   if (installations.length === 0) {
-    if (!chromium.path) {
-      await chromium.install();
-    }
-
-    process.env.CHROME_PATH = chromium.path;
+    await useChromium();
   }
+};
+
+const useChromium = async () => {
+  if (!chromium.path) {
+    await chromium.install();
+  }
+
+  process.env.CHROME_PATH = chromium.path;
 };
 
 async function writeReport(url, flags = {}, defaultChromeFlags = [], lighthouseFlags = {}) {
   const { chromeFlags, configPath, budgetPath, ...extraLHFlags } = lighthouseFlags;
   const customChromeFlags = chromeFlags ? chromeFlags.split(',') : [];
 
-  if (flags.chromiumFallback) {
+  if (flags.chromiumForce) {
+    await useChromium();
+  } else if (flags.chromiumFallback) {
     await checkChromiumFallback();
   }
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "chrome-launcher": "^0.13.2",
+    "chromium": "^3.0.1",
     "lighthouse": "^6.0.0",
     "meow": "^6.1.0",
     "mkdirp": "^0.5.5",


### PR DESCRIPTION
Hi there people...

I want to use lighthouse-ci on CI servers that may or may not have chrome installed.

There are two options I am currently considering:

1. Creating my own wrapper project around lighthouse-ci which simply downloads Chromium and then calls lighthouse-ci
OR
2. Add this functionality to lighthouse-ci (hence this PR)

This change does nothing unless both these conditions are true:

* Chrome is not found in any other way
* The user has opted in with `--chromium-fallback`

Or we could make the fallback default unless the user opts out?

Over to you... If you are not interested close this PR and I'll go with Option 1


