### PR TITLE
feat(lighthouse-reporter): Better reports

### DIFF
--- a/__tests__/reporter.test.js
+++ b/__tests__/reporter.test.js
@@ -3,7 +3,7 @@ const writeReport = require('../lib/lighthouse-reporter');
 describe('Reporter', () => {
   it('should launch Chrome and generate a report', async () => {
     jest.setTimeout(20000); // Allows more time to run all tests
-    const result = await writeReport('http://www.google.com');
+    const result = await writeReport('http://example.com/');
     expect(result).toEqual(
       expect.objectContaining({
         categoryReport: {

--- a/lib/lighthouse-reporter.js
+++ b/lib/lighthouse-reporter.js
@@ -11,6 +11,7 @@ const util = require('util');
 const lighthouse = require('lighthouse');
 const chromeLauncher = require('chrome-launcher');
 const ReportGenerator = require('lighthouse/lighthouse-core/report/report-generator');
+const chalk = require('chalk');
 const { createDefaultConfig, getOwnProps, convertToBudgetList, convertToResourceKey } = require('./helpers');
 
 const readFile = util.promisify(fs.readFile);
@@ -77,6 +78,20 @@ const launchChromeAndRunLighthouse = async (url, chromeFlags, lighthouseFlags, c
 
   const result = await lighthouse(url, flags, config);
   await chrome.kill();
+
+  if (!result || !result.lhr) {
+    throw new Error('Something went wrong when running Lighthouse against the given url');
+  }
+
+  if (result.lhr.runtimeError) {
+    throw new Error(result.lhr.runtimeError.message);
+  }
+  if (result.lhr.runWarnings.length) {
+    for (const warningMsg of result.lhr.runWarnings) {
+      console.warn(`\n${chalk.yellow('WARNING:')} ${warningMsg}`);
+    }
+    console.warn('\n');
+  }
 
   return result;
 };

--- a/lib/lighthouse-reporter.js
+++ b/lib/lighthouse-reporter.js
@@ -86,10 +86,12 @@ const launchChromeAndRunLighthouse = async (url, chromeFlags, lighthouseFlags, c
   if (result.lhr.runtimeError) {
     throw new Error(result.lhr.runtimeError.message);
   }
-  if (result.lhr.runWarnings.length) {
-    for (const warningMsg of result.lhr.runWarnings) {
-      console.warn(`\n${chalk.yellow('WARNING:')} ${warningMsg}`);
+
+  if (result.lhr.runWarnings.length >= 1) {
+    for (const warningMessage of result.lhr.runWarnings) {
+      console.warn(`\n${chalk.yellow('WARNING:')} ${warningMessage}`);
     }
+
     console.warn('\n');
   }
 


### PR DESCRIPTION
- Show error and fail the task when there's a problem with the entered URL instead of silently fail and display a wrong successful message
- When warnings are available, display them directly to the terminal for the user to be aware

Closes #62, #56